### PR TITLE
fix: changes name of datablock to correspond with the helm chart default

### DIFF
--- a/kubernetes-rke2/os_cinder.yaml.tpl
+++ b/kubernetes-rke2/os_cinder.yaml.tpl
@@ -14,7 +14,7 @@ spec:
       create: true
       name: cinder-csi-cloud-config
       data:
-        cloud-config: |-
+        cloud.conf: |-
             [Global]
             auth-url=${auth_url}
             application-credential-id=${app_id}


### PR DESCRIPTION
The default value in the helm chart for config is cloud.conf.