### PR TITLE
added a temporary? patch for the CCM

### DIFF
--- a/kubernetes-rke2/os_ccm.yaml.tpl
+++ b/kubernetes-rke2/os_ccm.yaml.tpl
@@ -20,3 +20,6 @@ spec:
         floating-network-id: ${floating_network_id}
         floating-subnet-id: ${floating_subnet_id}
         subnet-id: ${subnet_id}
+      image:
+        repository: docker.io/k8scloudprovider/openstack-cloud-controller-manager
+        tag: "v1.24.0"


### PR DESCRIPTION
This is a fix for a problem  that manifests itself as a permission problem in in nginx ingress controller


> 11s         Warning   SyncLoadBalancerFailed   service/quickstart-ingress-nginx-controller                Error syncing load balancer: failed to ensure load balancer: failed to patch service object default/quickstart-ingress-nginx-controller: services "quickstart-ingress-nginx-controller" is forbidden: User "system:serviceaccount:kube-system:cloud-controller-manager" cannot patch resource "services" in API group "" in the namespace "default"

